### PR TITLE
Correct extension name.

### DIFF
--- a/welcome/welcome-owner.md
+++ b/welcome/welcome-owner.md
@@ -30,7 +30,7 @@ Just follow these steps to start sharing:
     <td>
         <strong>Visual Studio Code</strong><br />
         1. Install <a href="https://code.visualstudio.com/">Visual Studio Code</a> (1.20.0+) for Windows (7, 8.1, or 10) or macOS <b>(Sierra & up).</b><br />
-        2. Download and install the Visual Studio Live Share extension from the marketplace. <br />
+        2. Download and install the VS Live Share extension from the marketplace. <br />
         3. Reload and wait for dependencies to download and install (see status bar).<br />
         <a href="https://aka.ms/vsls-dl/vscode"><img src="media/download.png"></a>
     </td>


### PR DESCRIPTION
Picture attached of how the extension is named in the marketplace.
![image](https://user-images.githubusercontent.com/9045825/37728289-17236d86-2cf7-11e8-8c3f-a0f14d07af50.png)

Open Question: Does the Visual Studio 2017 marketplace also call it VS Live Share and we should update line 24 of this doc as well?