### PR TITLE
Manual Join: fix Visual Studio link

### DIFF
--- a/docs/reference/manual-join.md
+++ b/docs/reference/manual-join.md
@@ -76,7 +76,7 @@ Quickstarts
 How-tos
 
 - [How-to: Collaborate using Visual Studio Code](../use/vscode.md)
-- [How-to: Collaborate using Visual Studio](../use/vscode.md)
+- [How-to: Collaborate using Visual Studio](../use/vs.md)
 - [How-to: Provide feedback](../support.md)
 
 Reference


### PR DESCRIPTION
The links on How-tos are both to VS Code, this fixes the VS link.