### PR TITLE
Reduce .NET Core deps, handle running as root, conditional install

### DIFF
--- a/docs/reference/linux.md
+++ b/docs/reference/linux.md
@@ -2,7 +2,7 @@
 title: "Linux installation details -  Visual Studio Live Share | Microsoft Docs"
 description: "Detailed information on installing Visual Studio Live Share on Linux."
 ms.custom:
-ms.date: 05/19/2018
+ms.date: 10/6/2018
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
@@ -23,7 +23,7 @@ Creative Commons Attribution 4.0 License (International): https://creativecommon
 
 # Linux installation details
 
-Linux is a highly variable environment and with the sheer number of desktop environments and distributions can be complicated to get working. If you stick to supported versions of **Ubuntu Desktop** (16.04+) or **Fedora Workstation** (27+) and only use **official distributions of VS Code** , you should find the process straight forward. However, in the event that you are using a non-standard configuration or downstream distribution, you may or may not run into some hiccups. This document provides some information on requirements and some troubleshooting details that might help you get up and running even if you configuration is only community supported.
+Linux is a highly variable environment and with the sheer number of desktop environments and distributions can be complicated to get working. If you stick to supported versions of **Ubuntu Desktop** (16.04+), **CentOS 7**, or **Fedora Workstation** (27+) and only use **official distributions of VS Code**, you should find the process straight forward. However, in the event that you are using a non-standard configuration or downstream distribution, you may or may not run into some hiccups. This document provides some information on requirements and some troubleshooting details that might help you get up and running even if you configuration is only community supported. Note that Live Share only supports **64-bit Linux**.
 
 ## Install Linux prerequisites
 
@@ -39,48 +39,9 @@ If you **prefer not to have VS Code run the command for you**, you can also opt 
 
     wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && chmod +x ~/vsls-reqs && ~/vsls-reqs
 
-### Manual prerequisite installation
-
- While we recommend using Live Share's dependency install script, this section provides further details on  library requirements in the event you want perform these steps yourself or are using a distribution not supported by the script.
-
-For typical missing libraries in vanilla installations, see [tips by distribution](#tips-by-distribution) and [tips for community supported distributions](#tips-for-unsupported-distros).
-
-#### Debian / Ubuntu
-
-> **Critical Note:** Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2 installed** or the Live Share agent may crash. You will need to remove one of these libraries if both are installed. Use `sudo apt remove libssl1.0.0` to or `sudo apt remove libssl1.0.2` to remove one. Pay close attention to what else will be removed when wto ensure this will not negatively affect your system. See [here](https://github.com/dotnet/core/issues/973) for additional information on this .NET Core bug.
-
-Libraries may be installed on Debian/Ubuntu based distributions by running `sudo apt install <library-name>` in a terminal.
-
-For Ubuntu based distributions including Mint, run:
-
-    sudo apt install libssl1.0.0 libkrb5-3 zlib1g libicu[0-9][0-9] gnome-keyring libsecret-1-0 desktop-file-utils x11-utils
-
-For Debian 9 and non-Ubuntu downstream distributions, run:
-
-    sudo apt install libssl1.0.2 libkrb5-3 zlib1g libicu57 gnome-keyring libsecret-1-0 desktop-file-utils x11-utils
-
-#### Fedora / CentOS / RHL
-
-Libraries may be installed on Fedora/CentOS/RHL based distributions by running `sudo yum install <library-name>` in a terminal. For example, this will install everything:
-
-    sudo yum install openssl-libs krb5-libs zlib libicu libsecret gnome-keyring desktop-file-utils xorg-x11-utils
-
-#### Detailed library requirements
-
-Visual Studio Live Share's native library requirements come from its use of .NET Core 2.1, libsecret to persist credentials, and its browser integration. The following table summerizes these requirements on .NET Core supported Linux distributions.
-
-| Distribution | .NET Core Reqs | Credential Storage  Reqs| Browser Integration Reqs |
-|--------------|-----------|--------------------|------------|
-| Ubuntu and downstream distributions | `libssl1.0.0 libkrb5-3 zlib1g libicu55` (for Ubuntu 16.04, Mint 18.3 or `libicu57` (for Ubuntu 17.10) or `libicu60 ` (for Ubuntu 18.04) | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils`, `x11-utils` |
-| Debian 9 and downstream distributions | `libssl1.0.2 libkrb5-3 zlib1g libicu57` | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils x11-utils` |
-| RHL / CentOS/ Fedora | `openssl-libs krb5-libs zlib libicu` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xorg-x11-utils` |
-| Alpine Linux | `openssl1.0 icu krb5 zlib` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xprop`
-
-Other distributions will require the same libraries, but their package names may vary. You can find some of these in the [tips for community supported distributions](#tips-for-unsupported-distros) section below.
-
 ## Tips by distribution
 
-While the prerequisite install script above should cover Debian / Ubuntu and RHL / Fedora / CentOS, you may be wondering what is typically missing from vanilla installations of these distributions. The following list shows the key libraries that were missing in a fresh install of the distribution. The list also provides some tips that can help you get up and running if you hit a problem.
+While the prerequisite install script above should cover Debian / Ubuntu and RHL / Fedora / CentOS, you may be wondering what is typically missing from vanilla installations of related distributions. The following list shows the key libraries that were missing in a fresh install of the distribution. The list also provides some tips that can help you get up and running if you hit a problem.
 
 | Distribution | Vanilla install missing libraries | Additional steps |
 |--------|-------------------|----|
@@ -90,15 +51,16 @@ While the prerequisite install script above should cover Debian / Ubuntu and RHL
 | Kubuntu 16.04 (64-bit) | `gnome-keyring desktop-file-utils` | <ul><li>If you run into trouble with Live Share's browser integration, be sure `desktop-file-utils` is installed and then restart VS Code.</li></ul> |
 | Xubuntu 18.04 (64-bit) |&lt;none&gt;  | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
 | Xubuntu 16.04 (64-bit) | &lt;none&gt; | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
+| Mint 19 Cinnamon (64-bit) | &lt;none&gt;  | &lt;none&gt; |
 | Mint 18.3 Cinnamon (64-bit) | &lt;none&gt;  | &lt;none&gt; |
 | Debian 9 GNOME Desktop (64-bit) | &lt;none&gt; | <ul><li>You will need to install `sudo` and add your user to the sudo group.</li><li>Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2** installed. Use `sudo apt remove libssl1.0.0` to remove the older version if it is installed in addition to 1.0.2. See [here](https://github.com/dotnet/core/issues/973) for details.</ul>  |
-| Fedora Workstation 27 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | Fedora Workstation 28 (64-bit) | &lt;none&gt; | &lt;none&gt; |
+| Fedora Workstation 27 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | CentOS 7 GNOME Desktop (64-bit) | &lt;none&gt; | &lt;none&gt; |
 
 See **[tips for community supported distributions](#tips-for-community-supported-distros)** for information about whether certain non-Debian / Ubuntu or RHL based distributions are working or not.
 
-Note that the Linux ecosystem moves quickly and package names will be different in certain distributions, so your results may vary. Additional details can be found above on the libraries Live Share needs.
+Note that the Linux ecosystem moves quickly and package names will be different in certain distributions, so your results may vary. Additional details can be found [below](#detailed-library-requirements) on the libraries Live Share needs.
 
 ## Tips for community supported distros
 <a name="tips-for-unsupported-distros"></a>
@@ -115,9 +77,48 @@ Distributions outside of the Debian / Ubuntu or RHL trees are not officially sup
 | Solus 3 (64-bit) | Yes | `xprop`. The `vscode` package also needs to be on at least version 57. | <ul><li>Use the prerequisite install script.</li><li>Versions of the `vscode` package prior to release 57 were missing required product.json ([see below](#vs-code-oss-issues)).</li></ul> |
 | Gentoo (64-bit) | Yes | Highly variable. Possible missing packages: `dev-libs/openssl-1.0.2 net-libs/libgsasl dev-libs/icu sys-libs/zlib sys-apps/util-linux app-crypt/libsecret gnome-base/gnome-keyring x11-apps/xprop`| <ul><li>The `visual-studio-code` package in the **jorgicio** overlay is known to work.</li></ul>
 
-### VS Code OSS Issues
+## Install prerequisites manually
 
-> **ArchLinux/Manjaro Users:** Use the [visual-studio-bin](https://aur.archlinux.org/packages/visual-studio-code-bin) AUR package to avoid this problem.
+ While we recommend using Live Share's **dependency install script**, this section provides further details on library requirements in the event you want perform these steps yourself or are using a distribution not supported by the script.
+
+Typical missing libraries in vanilla installations can be found in the [tips by distribution](#tips-by-distribution) and [tips for community supported distributions](#tips-for-unsupported-distros) sections.
+
+### Detailed library requirements
+
+Visual Studio Live Share's native library requirements come from its use of .NET Core 2.1, libsecret to persist credentials, and its browser integration. The following table summarizes these requirements for distributions officially supported by .NET Core.
+
+| Distribution | .NET Core Reqs | Credential Storage  Reqs| Browser Integration Reqs |
+|--------------|-----------|--------------------|------------|
+| Ubuntu and downstream distributions | `libssl1.0.0 libkrb5-3 zlib1g libicu55` (for Ubuntu 16.04, Mint 18.3) or `libicu57` (for Ubuntu 17.10) or `libicu60 `(for Ubuntu 18.04, Mint 19) | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils x11-utils` |
+| Debian 9 and downstream distributions | `libssl1.0.2 libkrb5-3 zlib1g libicu57` | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils x11-utils` |
+| RHL / CentOS/ Fedora | `openssl-libs krb5-libs zlib libicu` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xorg-x11-utils` |
+| Alpine Linux | `openssl1.0 icu krb5 zlib` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xprop`
+
+While other distributions require the same libraries, their package names may vary. You can find some of these in the [tips for community supported distributions](#tips-for-unsupported-distros) section.
+
+### Debian / Ubuntu
+
+> **Critical Note:** Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2 installed** or the Live Share agent may crash. You will need to remove one of these libraries if both are installed. Use `sudo apt remove libssl1.0.0` to or `sudo apt remove libssl1.0.2` to remove one. Pay close attention to what else will be removed when wto ensure this will not negatively affect your system. See [here](https://github.com/dotnet/core/issues/973) for additional information on this .NET Core bug.
+
+Libraries may be installed on Debian/Ubuntu based distributions by running `sudo apt install <library-name>` in a terminal.
+
+For Ubuntu based distributions including Mint, run:
+
+    sudo apt install libssl1.0.0 libkrb5-3 zlib1g libicu[0-9][0-9] gnome-keyring libsecret-1-0 desktop-file-utils x11-utils
+
+For Debian 9 and non-Ubuntu downstream distributions, run:
+
+    sudo apt install libssl1.0.2 libkrb5-3 zlib1g libicu57 gnome-keyring libsecret-1-0 desktop-file-utils x11-utils
+
+### Fedora / CentOS / RHL
+
+Libraries may be installed on Fedora/CentOS/RHL based distributions by running `sudo yum install <library-name>` in a terminal. For example, this will install everything:
+
+    sudo yum install openssl-libs krb5-libs zlib libicu libsecret gnome-keyring desktop-file-utils xorg-x11-utils
+
+## VS Code OSS Issues
+
+> **Arch Linux/Manjaro Users:** Use the [visual-studio-bin](https://aur.archlinux.org/packages/visual-studio-code-bin) AUR package to avoid this problem.
 
 Packages of Visual Studio Code that are either vanilla or modified versions of VS Code OSS can be missing a critical value in `product.json` file that prevents Visual Studio Live Share from activating.
 
@@ -128,7 +129,7 @@ To verify this is your issue, check the contents of `product.json`. The file's l
 - `/usr/share/code/resources/app/product.json`
 - `/usr/share/vscode/resources/app/product.json`
 
-If the `extensionAllowedProposedApi` property is missing or you do not see "ms-vsliveshare.vsliveshare" referenced, you are using an OSS version with this problem. **Contact the VS Code distribution owner to get the issue patched.**
+If the `extensionAllowedProposedApi` property is missing or you do not see "ms-vsliveshare.vsliveshare" referenced, you are using an OSS version with this problem. 
 
 As a **workaround**, you can add the following into the product.json:
 
@@ -146,12 +147,11 @@ Visual Studio Live Share typically **does not require additional installation st
 
 To accomplish this, Live Share automatically places a desktop file in `~/.local/share/applications` and the required launcher itself in `~/.local/share/vsliveshare` when the extension first initializes. No action is required on your part if this succeeds.
 
-In some cases, distributions either do not support this location or require tweaks to get it to work with their vanilla installs (e.g. CentOS 7). In these cases, Live Share falls back to using `/usr/local/share` instead. As a result, **you may be notified that your admin (sudo) password is required** to complete the installation process. A terminal window will appear telling you where the browser launcher will be installed. Simply enter your password when prompted and press enter once the installation completes to close the terminal window.
+In some cases, distributions either do not support this location or require tweaks to get it to work with their vanilla installs. In these cases, Live Share falls back to using `/usr/local/share` instead. As a result, **you may be notified that your admin (sudo) password is required** to complete the installation process. A terminal window will appear telling you where the browser launcher will be installed. Simply enter your password when prompted and press enter once the installation completes to close the terminal window.
 
 If you'd prefer to run the command yourself instead, you can click "Copy instead" which will copy the terminal command to the clipboard instead.
 
 Finally, if you opt to skip this step entirely, you can still [join collaboration sessions manually](../use/vscode.md#join-manually), but you will not be able to join by opening an invite link in the browser. Note that you can always access the command again later, by hitting **Ctrl+Shift+P / Cmd+Shift+P** and selecting the "Live Share: Launcher Setup" command.
-
 
 ## See also
 

--- a/docs/reference/linux.md
+++ b/docs/reference/linux.md
@@ -37,13 +37,13 @@ If you see a message indicating the script does not support your distribution, s
 
 If you **prefer not to have VS Code run the command for you**, you can also opt to re-run the very latest version of this script at any time manually by running the following command from a Terminal window:
 
-    wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && bash ~/vsls-reqs
+    wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && chmod +x ~/vsls-reqs && ~/vsls-reqs
 
 ### Manual prerequisite installation
 
  While we recommend using Live Share's dependency install script, this section provides further details on  library requirements in the event you want perform these steps yourself or are using a distribution not supported by the script.
 
-For typical missing libraries in vanilla installations, see [tips by distribution](#tips-by-distribution) and [tips for community supported distributions](#tips-for-unsupported-distros). 
+For typical missing libraries in vanilla installations, see [tips by distribution](#tips-by-distribution) and [tips for community supported distributions](#tips-for-unsupported-distros).
 
 #### Debian / Ubuntu
 

--- a/docs/reference/linux.md
+++ b/docs/reference/linux.md
@@ -39,94 +39,59 @@ If you **prefer not to have VS Code run the command for you**, you can also opt 
 
     wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && bash ~/vsls-reqs
 
-### Details on required libraries
+### Manual prerequisite installation
 
-> **Critical Note:**  Using Live Share on any distribution of Linux will require **curl/libcurl with Kerberos support** compiled in it or you will see sign in failures. Supported distributions have this support in their base libcurl/curl packages, but if you've custom compiled curl be sure Kerberos support is included. Other unsupported distributions may require additional steps.
+ While we recommend using Live Share's dependency install script, this section provides further details on  library requirements in the event you want perform these steps yourself or are using a distribution not supported by the script.
+
+For typical missing libraries in vanilla installations, see [tips by distribution](#tips-by-distribution) and [tips for community supported distributions](#tips-for-unsupported-distros). 
 
 #### Debian / Ubuntu
 
-Visual Studio Live Share uses the .NET Core runtime which requires a number of libraries be installed. The following libraries are required for Debian/Ubuntu based distributions or derivatives:
+> **Critical Note:** Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2 installed** or the Live Share agent may crash. You will need to remove one of these libraries if both are installed. Use `sudo apt remove libssl1.0.0` to or `sudo apt remove libssl1.0.2` to remove one. Pay close attention to what else will be removed when wto ensure this will not negatively affect your system. See [here](https://github.com/dotnet/core/issues/973) for additional information on this .NET Core bug.
 
-- libunwind8
-- liblttng-ust0
-- libcurl3 (Ubuntu 16.04, 17.10, Mint 18.3, Debian 9) or libcurl4 (Ubuntu 18.04)
-- libssl1.0.0 (Ubuntu 16.04, 17.10, 18.04) or libssl1.0.2 (Debian 9)
-- libuuid1
-- libkrb5-3
-- zlib1g
-- libicu55 (for Ubuntu 16.04, Mint 18.3), libicu57 (for Ubuntu 17.10, Debian 9), or libicu60 (for Ubuntu 18.04)
-- gettext
-- apt-transport-https
-- gnome-keyring
-- libsecret-1-0
-- desktop-file-utils
-- x11-utils
+Libraries may be installed on Debian/Ubuntu based distributions by running `sudo apt install <library-name>` in a terminal.
 
-> **Critical Note:** Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2 installed** or the Live Share agent may crash. Use `sudo apt remove libssl1.0.0` to remove the older version if both are installed. See [here](https://github.com/dotnet/core/issues/973) for additional information on this .NET Core bug.
+For Ubuntu based distributions including Mint, run:
 
-Libraries may be installed on Debian/Ubuntu based distributions by running `sudo apt install <library-name>` in a terminal. For Ubuntu 16.04, 17.10, and Mint 18.3 run:
+    sudo apt install libssl1.0.0 libkrb5-3 zlib1g libicu[0-9][0-9] gnome-keyring libsecret-1-0 desktop-file-utils x11-utils
 
-    sudo apt install libssl1.0.0 libcurl3 libunwind8 liblttng-ust0 libuuid1 libkrb5-3 zlib1g gnome-keyring libsecret-1-0 desktop-file-utils gettext apt-transport-https x11-utils libicu??
+For Debian 9 and non-Ubuntu downstream distributions, run:
 
-For Ubuntu 18.04, run:
-
-    sudo apt install libssl1.0.0 libcurl4 libunwind8 liblttng-ust0 libuuid1 libkrb5-3 zlib1g gnome-keyring libsecret-1-0 desktop-file-utils gettext apt-transport-https x11-utils libicu??
-
-For Debian 9, run:
-
-    sudo apt install libssl1.0.2 libcurl3 libunwind8 liblttng-ust0 libuuid1 libkrb5-3 zlib1g gnome-keyring libsecret-1-0 desktop-file-utils gettext apt-transport-https x11-utils libicu??
+    sudo apt install libssl1.0.2 libkrb5-3 zlib1g libicu57 gnome-keyring libsecret-1-0 desktop-file-utils x11-utils
 
 #### Fedora / CentOS / RHL
 
-Fedora/CentOS/RHL requires similar packages to Debian / Ubuntu but with slightly different names:
-
-- libunwind
-- lttng-ust
-- libcurl
-- openssl-libs
-- libuuid
-- krb5-libs
-- libicu
-- zlib
-- gnome-keyring
-- libsecret
-- desktop-file-utils
-- xorg-x11-utils
-
 Libraries may be installed on Fedora/CentOS/RHL based distributions by running `sudo yum install <library-name>` in a terminal. For example, this will install everything:
 
-    sudo yum install libunwind lttng-ust libcurl openssl-libs libuuid krb5-libs libicu zlib gnome-keyring libsecret desktop-file-utils xorg-x11-utils
+    sudo yum install openssl-libs krb5-libs zlib libicu libsecret gnome-keyring desktop-file-utils xorg-x11-utils
 
-Other distributions will require the same libraries, but the package names may be subtly different. You can [read more about .NET Core 2.0 prerequisites for other distributions here](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x#linux-distribution-dependencies).
+#### Detailed library requirements
 
-## Linux browser integration
+Visual Studio Live Share's native library requirements come from its use of .NET Core 2.1, libsecret to persist credentials, and its browser integration. The following table summerizes these requirements on .NET Core supported Linux distributions.
 
-Visual Studio Live Share typically **does not require additional installation steps** to enable browser integration on Linux.
+| Distribution | .NET Core Reqs | Credential Storage  Reqs| Browser Integration Reqs |
+|--------------|-----------|--------------------|------------|
+| Ubuntu and downstream distributions | `libssl1.0.0 libkrb5-3 zlib1g libicu55` (for Ubuntu 16.04, Mint 18.3 or `libicu57` (for Ubuntu 17.10) or `libicu60 ` (for Ubuntu 18.04) | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils`, `x11-utils` |
+| Debian 9 and downstream distributions | `libssl1.0.2 libkrb5-3 zlib1g libicu57` | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils x11-utils` |
+| RHL / CentOS/ Fedora | `openssl-libs krb5-libs zlib libicu` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xorg-x11-utils` |
+| Alpine Linux | `openssl1.0 icu krb5 zlib` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xprop`
 
-To accomplish this, Live Share automatically places a desktop file in `~/.local/share/applications` and the required launcher itself in `~/.local/share/vsliveshare` when the extension first initializes. No action is required on your part if this succeeds.
-
-In some cases, distributions either do not support this location or require tweaks to get it to work with their vanilla installs (e.g. CentOS 7). In these cases, Live Share falls back to using `/usr/local/share` instead. As a result, **you may be notified that your admin (sudo) password is required** to complete the installation process. A terminal window will appear telling you where the browser launcher will be installed. Simply enter your password when prompted and press enter once the installation completes to close the terminal window.
-
-If you'd prefer to run the command yourself instead, you can click "Copy instead" which will copy the terminal command to the clipboard instead.
-
-Finally, if you opt to skip this step entirely, you can still [join collaboration sessions manually](../use/vscode.md#join-manually), but you will not be able to join by opening an invite link in the browser. Note that you can always access the command again later, by hitting **Ctrl+Shift+P / Cmd+Shift+P** and selecting the "Live Share: Launcher Setup" command.
+Other distributions will require the same libraries, but their package names may vary. You can find some of these in the [tips for community supported distributions](#tips-for-unsupported-distros) section below.
 
 ## Tips by distribution
 
 While the prerequisite install script above should cover Debian / Ubuntu and RHL / Fedora / CentOS, you may be wondering what is typically missing from vanilla installations of these distributions. The following list shows the key libraries that were missing in a fresh install of the distribution. The list also provides some tips that can help you get up and running if you hit a problem.
 
-> **Note:** One critical note for all distributions is that you will need a version of curl/libcurl with Kerberos support in it or you will see sign in failures even after dependencies are installed. Supported distributions have this support in their libcurl/curl packages, but if you've custom compiled curl be sure Kerberos support is included.
-
 | Distribution | Vanilla install missing libraries | Additional steps |
 |--------|-------------------|----|
-| Ubuntu Desktop 18.04 (64-bit) | `libcurl4 liblttng-ust0 apt-transport-https` | &lt;none&gt; |
+| Ubuntu Desktop 18.04 (64-bit) | &lt;none&gt;  | &lt;none&gt; |
 | Ubuntu Desktop 16.04 (64-bit) | &lt;none&gt; | &lt;none&gt; |
-| Kubuntu 18.04 (64-bit) | `libcurl4 liblttng-ust0 gnome-keyring desktop-file-utils gettext apt-transport-https` | <ul><li>If you run into trouble with Live Share's browser integration, be sure `desktop-file-utils` is installed and then restart VS Code.</li></ul> |
-| Kubuntu 16.04 (64-bit) | `libunwind8 liblttng-ust0 gnome-keyring desktop-file-utils` | <ul><li>If you run into trouble with Live Share's browser integration, be sure `desktop-file-utils` is installed and then restart VS Code.</li></ul> |
-| Xubuntu 18.04 (64-bit) |`libcurl4 liblttng-ust0 apt-transport-https` | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
-| Xubuntu 16.04 (64-bit) | `libunwind8 liblttng-ust0` | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
-| Mint 18.3 Cinnamon (64-bit) | `libcurl3` | &lt;none&gt; |
-| Debian 9 GNOME Desktop (64-bit) | `libunwind8 liblttng-ust0 apt-transport-https gettext` | <ul><li>You will need to install `sudo` if you have not already to run the automated prerequisite installer.</li><li>Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2** installed. Use `sudo apt remove libssl1.0.0` to remove the older version if it is installed in addition to 1.0.2. See [here](https://github.com/dotnet/core/issues/973) for details.</ul>  |
+| Kubuntu 18.04 (64-bit) | `gnome-keyring desktop-file-utils` | <ul><li>If you run into trouble with Live Share's browser integration, be sure `desktop-file-utils` is installed and then restart VS Code.</li></ul> |
+| Kubuntu 16.04 (64-bit) | `gnome-keyring desktop-file-utils` | <ul><li>If you run into trouble with Live Share's browser integration, be sure `desktop-file-utils` is installed and then restart VS Code.</li></ul> |
+| Xubuntu 18.04 (64-bit) |&lt;none&gt;  | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
+| Xubuntu 16.04 (64-bit) | &lt;none&gt; | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
+| Mint 18.3 Cinnamon (64-bit) | &lt;none&gt;  | &lt;none&gt; |
+| Debian 9 GNOME Desktop (64-bit) | &lt;none&gt; | <ul><li>You will need to install `sudo` and add your user to the sudo group.</li><li>Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2** installed. Use `sudo apt remove libssl1.0.0` to remove the older version if it is installed in addition to 1.0.2. See [here](https://github.com/dotnet/core/issues/973) for details.</ul>  |
 | Fedora Workstation 27 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | Fedora Workstation 28 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | CentOS 7 GNOME Desktop (64-bit) | &lt;none&gt; | &lt;none&gt; |
@@ -144,11 +109,11 @@ Distributions outside of the Debian / Ubuntu or RHL trees are not officially sup
 
 | Distribution | Working? | Vanilla install missing libraries | Additional Steps |
 |--------------|----------|-------------------|------------------|
-| ArchLinux (64-bit) | Yes | Varies. Use the prerequisite install script. Most common are `gnome-keyring` and `libsecret`.  | <ul><li>Use the [visual-studio-code-bin](https://aur.archlinux.org/packages/visual-studio-code-bin) AUR package for VS Code.</li><li>`sudo` will need to be installed  to use the automated prerequisite install script.</li><li>`gnome-keyring` may require additional [setup steps](https://wiki.archlinux.org/index.php/GNOME/Keyring) in some desktop environments.</lu><li>If you have custom compiled curl or libcurl, be sure to include Kerberos support (the default package includes it). See [here](https://github.com/MicrosoftDocs/live-share/issues/212) for details.</li></ul> |
-| Manjaro 17.1 (64-bit) | Yes | Use the prerequisite install script. | <ul><li>Use the [visual-studio-code-bin](https://aur.archlinux.org/packages/visual-studio-code-bin) AUR package for VS Code.</li><li>If you have custom compiled curl or libcurl, be sure to include Kerberos support (the default package includes it). See [here](https://github.com/MicrosoftDocs/live-share/issues/212) for details.</li></ul> |
-| openSuSE LEAP 15 KDE (64-bit) | Yes | `libopenssl1_0_0 gnome-keyring` | &lt;none&gt; |
-| Solus 3 (64-bit) | Yes | `xprop` needs to be installed and ensure the installed `curl` package is at least release 40 and the `vscode` package is at least 57. | <ul><li>Versions of the `vscode` package prior to release 57 were missing required product.json ([see below](#vs-code-oss-issues)).</li><li>Versions of `curl` prior to release 40 did not include Kerberos support required by .NET Core and Live Share. This support was added to unstable on 5/23/2018 and expected to land in stable by **5/25/2018**.</li></ul> |
-| Gentoo (64-bit) | Yes | Highly variable, but commonly missing a version of `net-misc/curl` built with the `kerberos` USE flag.<br /><br>Other possible missing packages: `sys-libs/libunwind dev-util/lttng-ust dev-libs/openssl-1.0.2 net-libs/libgsasl dev-libs/icu sys-libs/zlib sys-apps/util-linux app-crypt/libsecret gnome-base/gnome-keyring x11-apps/xprop`| <ul><li>The `visual-studio-code` package in the **jorgicio** overlay is known to work.</li><li>`net-misc/curl` must be compiled with Kerberos support. Add the `kerberos` USE flag to your /etc/portage/package.use file/folder for the package and install/reinstall. See [here](https://github.com/MicrosoftDocs/live-share/issues/212) for details.</li></ul>
+| ArchLinux (64-bit) | Yes | Varies. Use the prerequisite install script. Possible libraries: `gcr liburcu openssl-1.0 krb5 zlib icu gnome-keyring libsecret desktop-file-utils xprop` | <ul><li>Use the prerequisite install script.</li><li>Use the [visual-studio-code-bin](https://aur.archlinux.org/packages/visual-studio-code-bin) AUR package for VS Code.</li><li>`sudo` will need to be installed  to use the automated prerequisite install script.</li><li>`gnome-keyring` may require additional [setup steps](https://wiki.archlinux.org/index.php/GNOME/Keyring) in some desktop environments.</lu><li>If you have custom compiled curl or libcurl, be sure to include Kerberos support (the default package includes it). See [here](https://github.com/MicrosoftDocs/live-share/issues/212) for details.</li></ul> |
+| Manjaro 17.1 (64-bit) | Yes | `xorg-xprop liburcu` | <ul><li>Use the prerequisite install script.</li><li>Use the [visual-studio-code-bin](https://aur.archlinux.org/packages/visual-studio-code-bin) AUR package for VS Code.</li><li>If you have custom compiled curl or libcurl, be sure to include Kerberos support (the default package includes it). See [here](https://github.com/MicrosoftDocs/live-share/issues/212) for details.</li></ul> |
+| openSuSE LEAP 15 KDE (64-bit) | Yes | `libopenssl1_0_0 gnome-keyring` | <ul><li>Use the prerequisite install script.</li></ul> |
+| Solus 3 (64-bit) | Yes | `xprop`. The `vscode` package also needs to be on at least version 57. | <ul><li>Use the prerequisite install script.</li><li>Versions of the `vscode` package prior to release 57 were missing required product.json ([see below](#vs-code-oss-issues)).</li></ul> |
+| Gentoo (64-bit) | Yes | Highly variable. Possible missing packages: `dev-libs/openssl-1.0.2 net-libs/libgsasl dev-libs/icu sys-libs/zlib sys-apps/util-linux app-crypt/libsecret gnome-base/gnome-keyring x11-apps/xprop`| <ul><li>The `visual-studio-code` package in the **jorgicio** overlay is known to work.</li></ul>
 
 ### VS Code OSS Issues
 
@@ -174,6 +139,19 @@ As a **workaround**, you can add the following into the product.json:
      ]
 
 See [above](#tips-for-community-supported-distros) for additional details on whether the distribution you are using is known to work.
+
+## Linux browser integration
+
+Visual Studio Live Share typically **does not require additional installation steps** to enable browser integration on Linux.
+
+To accomplish this, Live Share automatically places a desktop file in `~/.local/share/applications` and the required launcher itself in `~/.local/share/vsliveshare` when the extension first initializes. No action is required on your part if this succeeds.
+
+In some cases, distributions either do not support this location or require tweaks to get it to work with their vanilla installs (e.g. CentOS 7). In these cases, Live Share falls back to using `/usr/local/share` instead. As a result, **you may be notified that your admin (sudo) password is required** to complete the installation process. A terminal window will appear telling you where the browser launcher will be installed. Simply enter your password when prompted and press enter once the installation completes to close the terminal window.
+
+If you'd prefer to run the command yourself instead, you can click "Copy instead" which will copy the terminal command to the clipboard instead.
+
+Finally, if you opt to skip this step entirely, you can still [join collaboration sessions manually](../use/vscode.md#join-manually), but you will not be able to join by opening an invite link in the browser. Note that you can always access the command again later, by hitting **Ctrl+Shift+P / Cmd+Shift+P** and selecting the "Live Share: Launcher Setup" command.
+
 
 ## See also
 

--- a/docs/reference/linux.md
+++ b/docs/reference/linux.md
@@ -53,7 +53,7 @@ While the prerequisite install script above should cover Debian / Ubuntu and RHL
 | Xubuntu 16.04 (64-bit) | &lt;none&gt; | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
 | Mint 19 Cinnamon (64-bit) | &lt;none&gt;  | &lt;none&gt; |
 | Mint 18.3 Cinnamon (64-bit) | &lt;none&gt;  | &lt;none&gt; |
-| Debian 9 GNOME Desktop (64-bit) | &lt;none&gt; | <ul><li>You will need to install `sudo` and add your user to the sudo group.</li><li>Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2** installed. Use `sudo apt remove libssl1.0.0` to remove the older version if it is installed in addition to 1.0.2. See [here](https://github.com/dotnet/core/issues/973) for details.</ul>  |
+| Debian 9 GNOME Desktop (64-bit) | &lt;none&gt; | <ul><li>You may need to install `sudo` and add your user to the sudo group.</li>  |
 | Fedora Workstation 28 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | Fedora Workstation 27 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | CentOS 7 GNOME Desktop (64-bit) | &lt;none&gt; | &lt;none&gt; |
@@ -97,8 +97,6 @@ Visual Studio Live Share's native library requirements come from its use of .NET
 While other distributions require the same libraries, their package names may vary. You can find some of these in the [tips for community supported distributions](#tips-for-unsupported-distros) section.
 
 ### Debian / Ubuntu
-
-> **Critical Note:** Be sure you do **not** have both **libssl1.0.0 and libssl1.0.2 installed** or the Live Share agent may crash. You will need to remove one of these libraries if both are installed. Use `sudo apt remove libssl1.0.0` to or `sudo apt remove libssl1.0.2` to remove one. Pay close attention to what else will be removed when wto ensure this will not negatively affect your system. See [here](https://github.com/dotnet/core/issues/973) for additional information on this .NET Core bug.
 
 Libraries may be installed on Debian/Ubuntu based distributions by running `sudo apt install <library-name>` in a terminal.
 

--- a/docs/use/vscode.md
+++ b/docs/use/vscode.md
@@ -40,7 +40,7 @@ Before you begin, you'll need to be sure you've got a version of Visual Studio C
 - **macOS**: Sierra (10.12) and above only.
     - _El Capitan (10.11) and below are not currently supported due to [.NET Core 2.0 requirements](https://go.microsoft.com/fwlink/?linkid=872315)._
 
-- **Linux**: 64-bit Ubuntu Desktop 16.04+, Fedora Workstation 27+
+- **Linux**: 64-bit Ubuntu Desktop 16.04+, Fedora Workstation 27+, CentOS 7
 
     - Live Share requires a number of [Linux prerequisites](#linux-install-steps) you may be prompted to install.
     - _32-bit Linux is not supported due to [.NET Core 2.0 requirements](https://go.microsoft.com/fwlink/?linkid=872314)._
@@ -65,7 +65,7 @@ By downloading and using Visual Studio Live Share, you agree to the [license ter
 
 ### Linux install steps
 
-Linux is a highly variable environment and with the sheer number of desktop environments and distributions can be complicated to get working. If you stick to supported versions of **Ubuntu Desktop** (16.04+) or **Fedora Workstation** (27+) and only use **official distributions of VS Code**, you should find the process straightforward. However, in the event that you are using a non-standard configuration or downstream distribution, you may or may not run into some hiccups. See [Linux installation details](../reference/linux.md) for more information.
+Linux is a highly variable environment and with the sheer number of desktop environments and distributions can be complicated to get working. If you stick to supported versions of **Ubuntu Desktop** (16.04+) or **Fedora Workstation** (27+), ***CentOS 7** and only use **official distributions of VS Code**, you should find the process straightforward. However, in the event that you are using a non-standard configuration or downstream distribution, you may or may not run into some hiccups. See [Linux installation details](../reference/linux.md) for more information.
 
 #### Install Linux prerequisites
 
@@ -79,7 +79,7 @@ If you see a message indicating the script does not support your distribution, s
 
 If you **prefer not to have VS Code run the command for you**, you can also opt to re-run the very latest version of this script at any time manually by running the following command from a Terminal window:
 
-    wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && bash ~/vsls-reqs
+    wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && chmod +x ~/vsls-reqs && ~/vsls-reqs
  
 #### Linux browser integration
 

--- a/docs/use/vscode.md
+++ b/docs/use/vscode.md
@@ -65,7 +65,7 @@ By downloading and using Visual Studio Live Share, you agree to the [license ter
 
 ### Linux install steps
 
-Linux is a highly variable environment and with the sheer number of desktop environments and distributions can be complicated to get working. If you stick to supported versions of **Ubuntu Desktop** (16.04+) or **Fedora Workstation** (27+), ***CentOS 7** and only use **official distributions of VS Code**, you should find the process straightforward. However, in the event that you are using a non-standard configuration or downstream distribution, you may or may not run into some hiccups. See [Linux installation details](../reference/linux.md) for more information.
+Linux is a highly variable environment and with the sheer number of desktop environments and distributions can be complicated to get working. If you stick to supported versions of **Ubuntu Desktop** (16.04+) or **Fedora Workstation** (27+), **CentOS 7** and only use **official distributions of VS Code**, you should find the process straightforward. However, in the event that you are using a non-standard configuration or downstream distribution, you may or may not run into some hiccups. See [Linux installation details](../reference/linux.md) for more information.
 
 #### Install Linux prerequisites
 

--- a/scripts/.gitattributes
+++ b/scripts/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.* text eol=lf

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -27,7 +27,7 @@ if [ "$3" = "false" ]; then BROWSERDEPS=0; else BROWSERDEPS=1; fi
 sudoif()
 {
     # Alpine returns nothing for $EUID, so assume root in this case
-    if [ "$EUID" != "" ] && [ $EUID -ne 0]; then
+    if [ "$EUID" != "" ] && [ $EUID -ne 0 ]; then
         set -- command sudo "$@"
     fi
     "$@"
@@ -212,7 +212,7 @@ elif type pacman > /dev/null 2>&1; then
 
     if [ $NETCOREDEPS -ne 0 ]; then
         # Install .NET Core dependencies
-        sudoif pacman -Sq --needed gcr liburcu openssl-1.0 krb5 icu zlib
+        sudoif pacman -Sq --noconfirm --needed gcr liburcu openssl-1.0 krb5 icu zlib
         if [ $? -ne 0 ]; then
             echo "(!) Installation failed! Press enter to dismiss this message."
             read
@@ -222,7 +222,7 @@ elif type pacman > /dev/null 2>&1; then
 
     if [ $KEYRINGDEPS -ne 0 ]; then
         # Install keyring dependencies
-        sudoif pacman -Sq --needed gnome-keyring libsecret
+        sudoif pacman -Sq --noconfirm --needed gnome-keyring libsecret
         if [ $? -ne 0 ]; then
             echo "(!) Installation failed! Press enter to dismiss this message."
             read
@@ -232,7 +232,7 @@ elif type pacman > /dev/null 2>&1; then
 
     if [ $BROWSERDEPS -ne 0 ]; then
         # Install browser integration dependencies
-        sudoif pacman -Sq --needed desktop-file-utils xorg-xprop
+        sudoif pacman -Sq --noconfirm --needed desktop-file-utils xorg-xprop
         if [ $? -ne 0 ]; then
             echo "(!) Installation failed! Press enter to dismiss this message."
             read

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -9,10 +9,10 @@
 echo ""
 echo "Visual Studio Live Share Linux Dependency Installer"
 echo ""
-echo "See https://aka.ms/vsls-docs/linux-prerequisites for manual instructions."
-echo ""
 echo "Visual Studio Live Share requires a number of prerequisites that this script"
 echo "will attempt to install for you. This process requires admin / root access."
+echo ""
+echo "See https://aka.ms/vsls-docs/linux-prerequisites for manual instructions."
 echo ""
 
 # Script can skip installing .NET Core, keyring, or browser integretion dependencies.
@@ -23,8 +23,7 @@ if [ "$2" = "false" ]; then KEYRINGDEPS=0; else KEYRINGDEPS=1; fi
 if [ "$3" = "false" ]; then BROWSERDEPS=0; else BROWSERDEPS=1; fi
 
 # If not already root, validate user has sudo access and error if not.
-# Alpine Linux returns nothing for $EUID, so assume root in this case.
-if [ "$EUID" != "" ] && [ $EUID -ne 0 ]; then
+if [! [ $(id -u) -eq 0 ]; then
     echo "To begin the installation process, your OS will now ask you to enter your"
     echo "admin / root (sudo) password."
     echo ""
@@ -46,7 +45,7 @@ fi
 # Wrapper function to only use sudo if not already root
 sudoif()
 {
-    if [ "$EUID" != "" ] && [ $EUID -ne 0 ]; then
+    if ! [ $(id -u) -eq 0 ]; then
         set -- command sudo "$@"
     fi
     "$@"

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -23,7 +23,7 @@ if [ "$2" = "false" ]; then KEYRINGDEPS=0; else KEYRINGDEPS=1; fi
 if [ "$3" = "false" ]; then BROWSERDEPS=0; else BROWSERDEPS=1; fi
 
 # If not already root, validate user has sudo access and error if not.
-if [! [ $(id -u) -eq 0 ]; then
+if [ $(id -u) -ne 0 ]; then
     echo "To begin the installation process, your OS will now ask you to enter your"
     echo "admin / root (sudo) password."
     echo ""
@@ -45,7 +45,7 @@ fi
 # Wrapper function to only use sudo if not already root
 sudoif()
 {
-    if ! [ $(id -u) -eq 0 ]; then
+    if [ $(id -u) -ne 0 ]; then
         set -- command sudo "$@"
     fi
     "$@"

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -23,10 +23,26 @@ if [ "$1" = "false" ]; then NETCOREDEPS=0; else NETCOREDEPS=1; fi
 if [ "$2" = "false" ]; then KEYRINGDEPS=0; else KEYRINGDEPS=1; fi
 if [ "$3" = "false" ]; then BROWSERDEPS=0; else BROWSERDEPS=1; fi
 
+# If not already root, validate user has sudo access and error if not.
+# Alpine Linux returns nothing for $EUID, so assume root in this case.
+if [ "$EUID" != "" ] && [ $EUID -ne 0 ]; then
+    echo "To complete the installation, your OS will now prompt you to enter your"
+    echo "admin (sudo) password."
+    echo ""
+    # Validate user actually can use sudo
+    sudo -v > /dev/null 2>&1;
+    if [ $? -ne 0 ]; then
+        echo "(!) Dependency installation failed! You do not have the needed admin (sudo) "
+        echo "    rights to install the needed dependencies. Contact your system administrator"
+        echo "    with the library specifics from the VS Live Share documentation here:"
+        echo "    https://aka.ms/vsls-docs/linux-required-lib-details"
+        exit 3
+    fi
+fi
+
 # Wrapper function to only use sudo if not already root
 sudoif()
 {
-    # Alpine returns nothing for $EUID, so assume root in this case
     if [ "$EUID" != "" ] && [ $EUID -ne 0 ]; then
         set -- command sudo "$@"
     fi

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -12,8 +12,7 @@ echo ""
 echo "See https://aka.ms/vsls-docs/linux-prerequisites for manual instructions."
 echo ""
 echo "Visual Studio Live Share requires a number of prerequisites that this script"
-echo "will attempt to install for you. Note you may be prompted for your admin (sudo)"
-echo "password during the installation process."
+echo "will attempt to install for you. This process requires admin / root access."
 echo ""
 
 # Script can skip installing .NET Core, keyring, or browser integretion dependencies.
@@ -26,16 +25,20 @@ if [ "$3" = "false" ]; then BROWSERDEPS=0; else BROWSERDEPS=1; fi
 # If not already root, validate user has sudo access and error if not.
 # Alpine Linux returns nothing for $EUID, so assume root in this case.
 if [ "$EUID" != "" ] && [ $EUID -ne 0 ]; then
-    echo "To complete the installation, your OS will now prompt you to enter your"
-    echo "admin (sudo) password."
+    echo "To begin the installation process, your OS will now ask you to enter your"
+    echo "admin / root (sudo) password."
     echo ""
     # Validate user actually can use sudo
     sudo -v > /dev/null 2>&1;
     if [ $? -ne 0 ]; then
-        echo "(!) Dependency installation failed! You do not have the needed admin (sudo) "
-        echo "    rights to install the needed dependencies. Contact your system administrator"
-        echo "    with the library specifics from the VS Live Share documentation here:"
+        echo ""
+        echo "(!) Dependency installation failed! You do not have the needed admin / root"
+        echo "    access to install Live Share's dependencies. Contact your system admin"
+        echo "    and ask them to install the required libraries described here:"
         echo "    https://aka.ms/vsls-docs/linux-required-lib-details"
+        echo ""
+        echo "Press enter to dismiss this message."
+        read
         exit 3
     fi
 fi

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -28,7 +28,7 @@ if [ $(id -u) -ne 0 ]; then
     echo "admin / root (sudo) password."
     echo ""
     # Validate user actually can use sudo
-    sudo -v > /dev/null 2>&1;
+    sudo -v > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo ""
         echo "(!) Dependency installation failed! You do not have the needed admin / root"

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -113,8 +113,7 @@ elif type apt-get > /dev/null 2>&1; then
             read
             exit 1
         fi
-        # On Debian, .NET Core will crash if there is more than one version of libssl1.0 installed.
-        # Remove one if this situation is detected. See https://github.com/dotnet/core/issues/973
+        # Determine which version of libssl to install
         LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 | sed -n -e '/^i/p' | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort)
         if [ $? -ne 0 ]; then
             echo "(!) Failed see if libssl already installed! Press enter to dismiss this message."
@@ -139,32 +138,7 @@ elif type apt-get > /dev/null 2>&1; then
                 fi
             fi
         else 
-            LIBSSLCOUNT=$(echo "$LIBSSL" | wc -l)
-            LIBSSLFIRSTPKG=$(echo "$LIBSSL" | head -n 1 | sed -e 's/...\t\(.*\):\(.*\)/\1/')
-            if [[ $LIBSSLCOUNT -gt 1 ]]; then
-                # More than one is installed - so see if we should remove one
-                echo ""
-                echo "(!) WARNING: $LIBSSLCOUNT sub-versions of libssl1.0 detected. This can crash Live Share."
-                echo ""
-                echo "This script can attempt to fix this by removing the package $LIBSSLFIRSTPKG."
-                echo "However, doing so MAY REMOVE OTHER PACKAGES ON YOUR SYSTEM. If you proceed, you"
-                echo "will presented with a complete list of libraries that will added and be removed."
-                echo "Please verify you want this list of packages removed and cancel if not."
-                echo ""
-                read -p "Attempt to fix by removing the library [Y/n]? "
-                if [[ "$REPLY" == "" ]] || [[ "$REPLY"  =~ ^[Yy] ]]; then
-                    # This can remove other packages, so skip "-yq" so user can review impact
-                    echo ""
-                    sudoif apt-get remove $LIBSSLFIRSTPKG
-                    if [ $? -ne 0 ]; then
-                        echo "(!) Failed to remove $LIBSSLFIRSTPKG! Press enter to dismiss this message."
-                        read
-                        exit 1
-                    fi
-                fi
-            else
-                echo "$LIBSSLFIRSTPKG already installed."
-            fi
+            echo "libssl1.0.x already installed."
         fi
     fi
 

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -128,7 +128,7 @@ elif type apt-get > /dev/null 2>&1; then
                 echo ""
                 echo "(!) WARNING: $LIBSSLCOUNT sub-versions of libssl1.0 detected. This can crash Live Share."
                 echo ""
-                echo "This script can attempt to fix this by removing the package \"$LIBSSLFIRSTPKG\"".
+                echo "This script can attempt to fix this by removing the package $LIBSSLFIRSTPKG."
                 echo "However, doing so MAY REMOVE OTHER PACKAGES ON YOUR SYSTEM. If you proceed, you"
                 echo "will presented with a complete list of libraries that will added and be removed."
                 echo "Please verify you want this list of packages removed and cancel if not."

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -175,6 +175,14 @@ elif type yum  > /dev/null 2>&1; then
     echo "(*) Detected RHL / Fedora / CentOS"
     echo ""
 
+    # Update package repo indexes
+    sudoif yum check-update
+    if [ $? -ne 0 ]; then
+        echo "(!) Installation failed! Press enter to dismiss this message."
+        read
+        exit 1
+    fi
+
     if [ $NETCOREDEPS -ne 0 ]; then
         # Install .NET Core dependencies
         sudoif yum -y install openssl-libs krb5-libs libicu zlib

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -42,7 +42,7 @@ if type zypper > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif zypper -n in libopenssl1_0_0 libicu krb5 libz1
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -52,7 +52,7 @@ if type zypper > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif zypper -n in gnome-keyring libsecret-1-0
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -62,7 +62,7 @@ if type zypper > /dev/null 2>&1; then
         # Install browser integration and clipboard dependencies
         sudoif zypper -n in desktop-file-utils xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -82,7 +82,7 @@ elif type apt-get > /dev/null 2>&1; then
     # Get latest package data
     sudoif apt-get update
     if [ $? -ne 0 ]; then
-        echo "(!) Installation failed! Press enter to dismiss this message."
+        echo "(!) Failed to re-index available packages! Press enter to dismiss this message."
         read
         exit 1
     fi
@@ -91,7 +91,7 @@ elif type apt-get > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif apt-get install -yq libicu[0-9][0-9] libkrb5-3 zlib1g
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -108,14 +108,14 @@ elif type apt-get > /dev/null 2>&1; then
             if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
                 sudoif apt-get install -yq libssl1.0.2
                 if [ $? -ne 0 ]; then
-                    echo "(!) Installation failed! Press enter to dismiss this message."
+                    echo "(!) libssl1.0.2 dependency installation failed! Press enter to dismiss this message."
                     read
                     exit 1
                 fi
             else    
                 sudoif apt-get install -yq libssl1.0.0
                 if [ $? -ne 0 ]; then
-                    echo "(!) Installation failed! Press enter to dismiss this message."
+                    echo "(!) libssl1.0.0 dependency installation failed! Press enter to dismiss this message."
                     read
                     exit 1
                 fi
@@ -139,7 +139,7 @@ elif type apt-get > /dev/null 2>&1; then
                     echo ""
                     sudoif apt-get remove $LIBSSLFIRSTPKG
                     if [ $? -ne 0 ]; then
-                        echo "(!) Installation failed! Press enter to dismiss this message."
+                        echo "(!) Failed to remove $LIBSSLFIRSTPKG! Press enter to dismiss this message."
                         read
                         exit 1
                     fi
@@ -154,7 +154,7 @@ elif type apt-get > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif apt-get install -yq gnome-keyring libsecret-1-0
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -164,7 +164,7 @@ elif type apt-get > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif apt-get install -yq desktop-file-utils x11-utils
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -177,17 +177,12 @@ elif type yum  > /dev/null 2>&1; then
 
     # Update package repo indexes
     sudoif yum check-update
-    if [ $? -ne 0 ]; then
-        echo "(!) Installation failed! Press enter to dismiss this message."
-        read
-        exit 1
-    fi
 
     if [ $NETCOREDEPS -ne 0 ]; then
         # Install .NET Core dependencies
         sudoif yum -y install openssl-libs krb5-libs libicu zlib
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -197,7 +192,7 @@ elif type yum  > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif yum -y install gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -207,7 +202,7 @@ elif type yum  > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif yum -y install desktop-file-utils xorg-x11-utils
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -222,7 +217,7 @@ elif type pacman > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif pacman -Sq --noconfirm --needed gcr liburcu openssl-1.0 krb5 icu zlib
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -232,7 +227,7 @@ elif type pacman > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif pacman -Sq --noconfirm --needed gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -242,7 +237,7 @@ elif type pacman > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif pacman -Sq --noconfirm --needed desktop-file-utils xorg-xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -257,7 +252,7 @@ elif type eopkg > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif eopkg -y it libicu openssl zlib kerberos
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -267,7 +262,7 @@ elif type eopkg > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif eopkg -y it gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -277,7 +272,7 @@ elif type eopkg > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif eopkg -y it desktop-file-utils xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -291,7 +286,7 @@ elif type apk > /dev/null 2>&1; then
     # Update package repo indexes
     sudoif apk update --wait 30
     if [ $? -ne 0 ]; then
-        echo "(!) Installation failed! Press enter to dismiss this message."
+        echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
         read
         exit 1
     fi
@@ -300,7 +295,7 @@ elif type apk > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif apk add --no-cache libssl1.0 icu krb5 zlib
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -310,7 +305,7 @@ elif type apk > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif apk add --no-cache gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -320,7 +315,7 @@ elif type apk > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif apk add --no-cache desktop-file-utils xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -56,7 +56,7 @@ if type zypper > /dev/null 2>&1; then
             read
             exit 1
         fi
-    fi
+    fi 
 
     if [ $BROWSERDEPS -ne 0 ]; then
         # Install browser integration and clipboard dependencies

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -60,7 +60,7 @@ if type zypper > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif zypper -n in libopenssl1_0_0 libicu krb5 libz1
         if [ $? -ne 0 ]; then
-            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -70,7 +70,7 @@ if type zypper > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif zypper -n in gnome-keyring libsecret-1-0
         if [ $? -ne 0 ]; then
-            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Keyring installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -80,7 +80,7 @@ if type zypper > /dev/null 2>&1; then
         # Install browser integration and clipboard dependencies
         sudoif zypper -n in desktop-file-utils xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Browser dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -109,7 +109,7 @@ elif type apt-get > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif apt-get install -yq libicu[0-9][0-9] libkrb5-3 zlib1g
         if [ $? -ne 0 ]; then
-            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -117,7 +117,7 @@ elif type apt-get > /dev/null 2>&1; then
         # Remove one if this situation is detected. See https://github.com/dotnet/core/issues/973
         LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 | sed -n -e '/^i/p' | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort)
         if [ $? -ne 0 ]; then
-            echo "(!) Installation failed! Press enter to dismiss this message."
+            echo "(!) Failed see if libssl already installed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -126,14 +126,14 @@ elif type apt-get > /dev/null 2>&1; then
             if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
                 sudoif apt-get install -yq libssl1.0.2
                 if [ $? -ne 0 ]; then
-                    echo "(!) libssl1.0.2 dependency installation failed! Press enter to dismiss this message."
+                    echo "(!) libssl1.0.2 installation failed! Press enter to dismiss this message."
                     read
                     exit 1
                 fi
             else    
                 sudoif apt-get install -yq libssl1.0.0
                 if [ $? -ne 0 ]; then
-                    echo "(!) libssl1.0.0 dependency installation failed! Press enter to dismiss this message."
+                    echo "(!) libssl1.0.0 installation failed! Press enter to dismiss this message."
                     read
                     exit 1
                 fi
@@ -172,7 +172,7 @@ elif type apt-get > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif apt-get install -yq gnome-keyring libsecret-1-0
         if [ $? -ne 0 ]; then
-            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Keyring installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -182,7 +182,7 @@ elif type apt-get > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif apt-get install -yq desktop-file-utils x11-utils
         if [ $? -ne 0 ]; then
-            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Browser dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -200,7 +200,7 @@ elif type yum  > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif yum -y install openssl-libs krb5-libs libicu zlib
         if [ $? -ne 0 ]; then
-            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -210,7 +210,7 @@ elif type yum  > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif yum -y install gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Keyring installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -220,7 +220,7 @@ elif type yum  > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif yum -y install desktop-file-utils xorg-x11-utils
         if [ $? -ne 0 ]; then
-            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Browser dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -235,7 +235,7 @@ elif type pacman > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif pacman -Sq --noconfirm --needed gcr liburcu openssl-1.0 krb5 icu zlib
         if [ $? -ne 0 ]; then
-            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -245,7 +245,7 @@ elif type pacman > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif pacman -Sq --noconfirm --needed gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Keyring installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -255,7 +255,7 @@ elif type pacman > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif pacman -Sq --noconfirm --needed desktop-file-utils xorg-xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Browser dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -270,7 +270,7 @@ elif type eopkg > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif eopkg -y it libicu openssl zlib kerberos
         if [ $? -ne 0 ]; then
-            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -280,7 +280,7 @@ elif type eopkg > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif eopkg -y it gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Keyring installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -290,7 +290,7 @@ elif type eopkg > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif eopkg -y it desktop-file-utils xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Browser dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -304,7 +304,15 @@ elif type apk > /dev/null 2>&1; then
     # Update package repo indexes
     sudoif apk update --wait 30
     if [ $? -ne 0 ]; then
-        echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
+        echo "(!) Failed to update package index. Press enter to dismiss this message."
+        read
+        exit 1
+    fi
+
+   # Upgrade to avoid package conflicts
+    sudoif apk upgrade 
+    if [ $? -ne 0 ]; then
+        echo "(!) Failed to upgrade. Press enter to dismiss this message."
         read
         exit 1
     fi
@@ -313,7 +321,7 @@ elif type apk > /dev/null 2>&1; then
         # Install .NET Core dependencies
         sudoif apk add --no-cache libssl1.0 icu krb5 zlib
         if [ $? -ne 0 ]; then
-            echo "(!) .NET Core dependency installation failed! Press enter to dismiss this message."
+            echo "(!) .NET Core dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -323,7 +331,7 @@ elif type apk > /dev/null 2>&1; then
         # Install keyring dependencies
         sudoif apk add --no-cache gnome-keyring libsecret
         if [ $? -ne 0 ]; then
-            echo "(!) Credential storage dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Keyring installation failed! Press enter to dismiss this message."
             read
             exit 1
         fi
@@ -333,7 +341,7 @@ elif type apk > /dev/null 2>&1; then
         # Install browser integration dependencies
         sudoif apk add --no-cache desktop-file-utils xprop
         if [ $? -ne 0 ]; then
-            echo "(!) Browser integration dependency installation failed! Press enter to dismiss this message."
+            echo "(!) Browser dependency install failed! Press enter to dismiss this message."
             read
             exit 1
         fi


### PR DESCRIPTION
This is an improved install script that addresses the following issues:

1. .NET Core 2.1 has fewer dependencies than 2.0, so the script is now reduced to known 2.1 deps only.
2. The script no longer requires sudo when running as root
3. The script can optionally skip keyring or browser integration dependencies (via args)
4. The script gracefully waits for existing dpkg operations to complete on Debian/Ubuntu based distros
5. The script no longer checks for libssl1.0.0 + libssl1.0.2 as this is not a problem with .NET Core 2.1
5. Adds Alpine Linux support

Testing on Linux desktop distros:
1. Open a terminal in the distro you want to test
2. Be sure `wget` is available - install it if not
3. Run: `
    wget -O ~/vsls-reqs https://raw.githubusercontent.com/MicrosoftDocs/live-share/netcore21-linuxdeps-update/scripts/linux-prereqs.sh && chmod +x ~/vsls-reqs && ~/vsls-reqs`

Testing with Debian/Ubuntu based Docker images:
```
docker run -it --rm <image> bash
apt update && apt install wget
wget -O ~/vsls-reqs https://raw.githubusercontent.com/MicrosoftDocs/live-share/netcore21-linuxdeps-update/scripts/linux-prereqs.sh && chmod +x ~/vsls-reqs && ~/vsls-reqs
````
Testing with Alpine Linux based Docker images:
```
docker run -it --rm <image> sh
apk add wget
wget -O ~/vsls-reqs https://raw.githubusercontent.com/MicrosoftDocs/live-share/netcore21-linuxdeps-update/scripts/linux-prereqs.sh && chmod +x ~/vsls-reqs && ~/vsls-reqs
````
