### PR TITLE
Fix for Fedora 29

### DIFF
--- a/docs/reference/linux.md
+++ b/docs/reference/linux.md
@@ -92,7 +92,7 @@ Visual Studio Live Share's native library requirements come from its use of .NET
 |--------------|-----------|--------------------|------------|
 | Ubuntu and downstream distributions | `libssl1.0.0 libkrb5-3 zlib1g libicu55` (for Ubuntu 16.04, Mint 18.3) or `libicu57` (for Ubuntu 17.10) or `libicu60 `(for Ubuntu 18.04, Mint 19) | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils x11-utils` |
 | Debian 9 and downstream distributions | `libssl1.0.2 libkrb5-3 zlib1g libicu57` | `libsecret-1-0 gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils x11-utils` |
-| RHL / CentOS/ Fedora | `openssl-libs krb5-libs zlib libicu` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xorg-x11-utils` |
+| RHL / CentOS/ Fedora | `openssl-libs krb5-libs zlib libicu` Fedora also requires `compat-openssl10`| `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xorg-x11-utils` |
 | Alpine Linux | `openssl1.0 icu krb5 zlib` | `libsecret gnome-keyring` (or libsecret supported keyring - Kwallet does not support libsecret) | `desktop-file-utils xprop`
 
 While other distributions require the same libraries, their package names may vary. You can find some of these in the [tips for community supported distributions](#tips-for-unsupported-distros) section.
@@ -113,7 +113,7 @@ For Debian 9 and non-Ubuntu downstream distributions, run:
 
 Libraries may be installed on Fedora/CentOS/RHL based distributions by running `sudo yum install <library-name>` in a terminal. For example, this will install everything:
 
-    sudo yum install openssl-libs krb5-libs zlib libicu libsecret gnome-keyring desktop-file-utils xorg-x11-utils
+    sudo yum install openssl-libs compat-openssl10 krb5-libs zlib libicu libsecret gnome-keyring desktop-file-utils xorg-x11-utils
 
 ## VS Code OSS Issues
 

--- a/docs/reference/linux.md
+++ b/docs/reference/linux.md
@@ -53,8 +53,9 @@ While the prerequisite install script above covers a variety of distributions, y
 | Xubuntu 16.04 (64-bit) | &lt;none&gt; | <ul><li>Ensure "Launch GNOME services on startup" is checked in the "Advanced" tab of "Session and Startup".</li><li>If you run into sign-in trouble, install `seahorse`, start "Passwords and Keys", verify you have "Login" keyring and that you can unlock it.</li></ul> |
 | Mint 19 Cinnamon (64-bit) | &lt;none&gt;  | &lt;none&gt; |
 | Mint 18.3 Cinnamon (64-bit) | &lt;none&gt;  | &lt;none&gt; |
+| Debian 10 (Buster) Testing (64-bit) | Release not stable, so unknown. | <ul><li>Debian Testing and Unstable (Sid) are not officially supported.</li><li>There is a [known issue](https://github.com/dotnet/corefx/issues/33179) in .NET Core that affects Live Share. </li><li>See [here for a workaround](https://github.com/dotnet/corefx/issues/33179#issuecomment-435118249).</li></ul> |
 | Debian 9 GNOME Desktop (64-bit) | &lt;none&gt; | <ul><li>You may need to install `sudo` and add your user to the sudo group to use the automated install script.</li>  |
-| Debian 10 (Buster) Testing (64-bit) | Release not stable, so unknown. | <ul><li>Debian Testing and Unstable (Sid) are not officially supported.</li><li>There is a [known issue](https://github.com/dotnet/corefx/issues/33179) with .NET Core that affects Live Share on Debian Buster. </li><li>See [here for a workaround](https://github.com/dotnet/corefx/issues/33179#issuecomment-435118249).</li></ul> |
+| Fedora Workstation 29 (64-bit) | `openssl-compat10` | &lt;none&gt; |
 | Fedora Workstation 28 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | Fedora Workstation 27 (64-bit) | &lt;none&gt; | &lt;none&gt; |
 | CentOS 7 GNOME Desktop (64-bit) | &lt;none&gt; | &lt;none&gt; |

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -191,7 +191,7 @@ elif type yum  > /dev/null 2>&1; then
         exitScript 1
     fi
 
-    checkNetCoreDeps sudoIf "yum -y install openssl-libs krb5-libs libicu zlib"
+    checkNetCoreDeps sudoIf "yum -y install openssl-libs openssl-compat10 krb5-libs libicu zlib"
     checkKeyringDeps sudoIf "yum -y install gnome-keyring libsecret"
     checkBrowserDeps sudoIf "yum -y install desktop-file-utils xorg-x11-utils"
 

--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -130,7 +130,7 @@ EOF
     fi
 fi
 
-#openSUSE - Has to be first as apt is aliased to zypper
+#openSUSE - Has to be first since apt-get is available but package names different
 if type zypper > /dev/null 2>&1; then
     echo "(*) Detected SUSE (unoffically/community supported)"
     checkNetCoreDeps sudoIf "zypper -n in libopenssl1_0_0 libicu krb5 libz1"
@@ -185,13 +185,26 @@ elif type yum  > /dev/null 2>&1; then
     # Update package repo indexes - returns 0 if no pacakges to upgrade,
     # 100 if there are packages to upgrade, and 1 on error
     echo -e "\n(*) Updating package lists..."
-    sudoIf "yum check-update --refresh"
+    sudoIf "yum check-update" >/dev/null 2>&1
     if [ $? -eq 1 ]; then
         echo "(!) Failed to update package list!"
         exitScript 1
     fi
-
-    checkNetCoreDeps sudoIf "yum -y install openssl-libs openssl-compat10 krb5-libs libicu zlib"
+    
+    checkNetCoreDeps sudoIf "yum -y install openssl-libs krb5-libs libicu zlib"  
+    # Install openssl-compat10 for Fedora 29. Does not exist in 
+    # CentOS, so validate package exists first.
+    if [ $NETCOREDEPS -ne 0 ]; then
+        if ! sudoIf "yum -q list compat-openssl10" >/dev/null 2>&1; then
+            echo "(*) compat-openssl10 not required."
+        else
+            if ! sudoIf "yum -y install compat-openssl10"; then
+                echo "(!) compat-openssl10 install failed"
+                exitScript 1
+            fi
+        fi
+    fi
+    
     checkKeyringDeps sudoIf "yum -y install gnome-keyring libsecret"
     checkBrowserDeps sudoIf "yum -y install desktop-file-utils xorg-x11-utils"
 


### PR DESCRIPTION
Resolves #1385. Fedora 29 does not appear to install compat-openssl10 with openssl-libs. Update checks for the existence of compat-openssl10 (since it doesn't exist on RHL or CentOS7) and installs it of detected.