### PR TITLE
add xdg-utils dependency for arch linux

### DIFF
--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -238,7 +238,7 @@ elif type pacman > /dev/null 2>&1; then
     echo "(*) Detected Arch Linux (unoffically/community supported)"
     checkNetCoreDeps sudoIf "pacman -Sq --noconfirm --needed gcr liburcu openssl-1.0 krb5 icu zlib"
     checkKeyringDeps sudoIf "pacman -Sq --noconfirm --needed gnome-keyring libsecret"
-    checkBrowserDeps sudoIf "pacman -Sq --noconfirm --needed desktop-file-utils xorg-xprop"
+    checkBrowserDeps sudoIf "pacman -Sq --noconfirm --needed desktop-file-utils xorg-xprop xdg-utils"
 
 #Solus
 elif type eopkg > /dev/null 2>&1; then


### PR DESCRIPTION
On Arch Linux, signing in with a GitHub or Microsoft account requires the xdg-open command which is a part of the xdg-utils package. xdg-utils is a transitive dependency of many desktop environments and the chrome browser, but I did not have it installed, so I was unable to sign in.