### PR TITLE
SEO work - fixed long title tags

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,5 @@
 ---
-title: "FAQ - Visual Studio Live Share | Microsoft Docs"
+title: "FAQ  | Microsoft Docs"
 description: "Frequently asked questions about Visual Studio Live Share."
 ms.custom:
 ms.date: 05/05/2018

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview - Visual Studio Live Share | Microsoft Docs"
+title: "Overview  | Microsoft Docs"
 description: "An overview of Visual Studio Live Share and its capabilities."
 ms.custom:
 ms.date: 10/30/2019

--- a/docs/overview/features.md
+++ b/docs/overview/features.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview - Visual Studio Live Share | Microsoft Docs"
+title: "Overview  | Microsoft Docs"
 description: "An overview of Visual Studio Live Share and its capabilities."
 ms.custom:
 ms.date: 10/30/2019

--- a/docs/overview/what's-new.md
+++ b/docs/overview/what's-new.md
@@ -1,5 +1,5 @@
 ---
-title: "Overview - Visual Studio Live Share | Microsoft Docs"
+title: "Overview  | Microsoft Docs"
 description: "New Live Share features and releases"
 ms.custom:
 ms.reviewer: ""

--- a/docs/quickstart/browser-join.md
+++ b/docs/quickstart/browser-join.md
@@ -1,5 +1,5 @@
 ---
-title: "Joining from the browser - Visual Studio Live Share | Microsoft Docs"
+title: "Joining from the browser  | Microsoft Docs"
 description: "Introducing joining from the browser"
 ms.date: 03/18/2020
 ms.reviewer: ""

--- a/docs/quickstart/join.md
+++ b/docs/quickstart/join.md
@@ -1,5 +1,5 @@
 ---
-title: "Join quickstart - Visual Studio Live Share | Microsoft Docs"
+title: "Join quickstart  | Microsoft Docs"
 description: "An abridged walkthrough on joining your first Visual Studio Live Share collaboration session."
 ms.custom:
 ms.date: 03/22/2018

--- a/docs/quickstart/share.md
+++ b/docs/quickstart/share.md
@@ -1,5 +1,5 @@
 ---
-title: "Share quickstart - Visual Studio Live Share | Microsoft Docs"
+title: "Share quickstart  | Microsoft Docs"
 description: "An abridged walkthrough on sharing your first project using a Visual Studio Live Share collaboration session."
 ms.custom:
 ms.date: 03/22/2018

--- a/docs/reference/connectivity.md
+++ b/docs/reference/connectivity.md
@@ -1,5 +1,5 @@
 ---
-title: "Connectivity - Visual Studio Live Share | Microsoft Docs"
+title: "Connectivity  | Microsoft Docs"
 description: "Information on connectivity and connection modes for Visual Studio Live Share."
 ms.custom:
 ms.date: 03/22/2018

--- a/docs/reference/contacts.md
+++ b/docs/reference/contacts.md
@@ -1,5 +1,5 @@
 ---
-title: "Presence- Visual Studio Live Share | Microsoft Docs"
+title: "Presence | Microsoft Docs"
 description: "Information on the presence service for contacts for Visual Studio Live Share."
 ms.custom:
 ms.date: 10/08/2019

--- a/docs/reference/insiders.md
+++ b/docs/reference/insiders.md
@@ -1,5 +1,5 @@
 ---
-title: "Insiders - Visual Studio Live Share | Microsoft Docs"
+title: "Insiders  | Microsoft Docs"
 description: "A description of the 'Insiders' channel within Visual Studio Live Share."
 ms.custom:
 ms.date: 04/02/2019

--- a/docs/reference/platform-support.md
+++ b/docs/reference/platform-support.md
@@ -1,5 +1,5 @@
 ---
-title: "Platform and language support - Visual Studio Live Share | Microsoft Docs"
+title: "Platform and language support  | Microsoft Docs"
 description: "An overview of platform and language support for Visual Studio Live share."
 ms.custom:
 ms.date: 04/25/2018

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,5 +1,5 @@
 ---
-title: "Security - Visual Studio Live Share | Microsoft Docs"
+title: "Security  | Microsoft Docs"
 description: "Information on the security features of Visual Studio Live Share."
 ms.custom:
 ms.date: 12/17/2018

--- a/docs/reference/use-cases.md
+++ b/docs/reference/use-cases.md
@@ -1,5 +1,5 @@
 ---
-title: "Common Use Cases - Visual Studio Live Share | Microsoft Docs"
+title: "Common Use Cases  | Microsoft Docs"
 description: "An overview of the use cases that developers are commonly leveraging Visual Studio Live Share for."
 ms.custom:
 ms.date: 05/21/2018

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,5 +1,5 @@
 ---
-title: "Platform and language support - Visual Studio Live Share | Microsoft Docs"
+title: "Platform and language support  | Microsoft Docs"
 description: "An overview of platform and language support for Visual Studio Live share."
 ms.custom:
 ms.date: 03/22/2018

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-title: "Troubleshooting - Visual Studio Live Share | Microsoft Docs"
+title: "Troubleshooting  | Microsoft Docs"
 description: "Troubleshooting tips and tricks for Visual Studio Live Share."
 ms.custom:
 ms.date: 03/22/2018

--- a/docs/use/vs.md
+++ b/docs/use/vs.md
@@ -1,5 +1,5 @@
 ---
-title: "Collaborate using Visual Studio - Visual Studio Live Share | Microsoft Docs"
+title: "Collaborate using Visual Studio  | Microsoft Docs"
 description: "A set of collaboration how-tos for Visual Studio and Live Share."
 ms.custom:
 ms.date: 04/25/2018

--- a/docs/user-profile.md
+++ b/docs/user-profile.md
@@ -1,5 +1,5 @@
 ---
-title: "User Profile - Visual Studio Live Share | Microsoft Docs"
+title: "User Profile  | Microsoft Docs"
 description: "An overview of how to view and remove your Visual Studio Live Share user profile."
 ms.custom:
 ms.date: 05/222/2018


### PR DESCRIPTION
The "- Visual Studio Live Share" portion of the title is redundant, since it's added via titleSuffix in docfx.json. Removing those for better SEO.