### PR TITLE
Script to auto-assign product-feedback label

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,22 @@
+# See https://github.com/marketplace/actions/close-stale-issues
+# As used here, "stale" is a misnomer. This uses the predefined action close-stale-issues to
+# label issues that have not been categorized with one of the triage label types
+# shown in line 22. Runs on the 1st day of every month.
+  
+name: label-untriaged-issues
+
+on:
+  schedule:
+    - cron: "* * 1 * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'Automatically marked uncategorized issue as product feedback'
+          stale-issue-label: 'product-feedback'
+          exempt-issue-labels: 'doc-bug,feature-request,doc-enhancement,doc-idea,doc-experience,product-issue,product-question'
+          days-before-issue-stale: 1


### PR DESCRIPTION
Adding a script to auto-label issues with the product-feedback label on the 1st of each month.