### PR TITLE
Update linux-prereqs.sh

### DIFF
--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -186,20 +186,7 @@ elif type yum  > /dev/null 2>&1; then
         exitScript 1
     fi
     
-    checkNetCoreDeps sudoIf "yum -y install openssl-libs krb5-libs libicu zlib"  
-    # Install openssl-compat10 for Fedora 29. Does not exist in 
-    # CentOS, so validate package exists first.
-    if [ $NETCOREDEPS -ne 0 ]; then
-        if ! sudoIf "yum -q list compat-openssl10" >/dev/null 2>&1; then
-            echo "(*) compat-openssl10 not required."
-        else
-            if ! sudoIf "yum -y install compat-openssl10"; then
-                echo "(!) compat-openssl10 install failed"
-                exitScript 1
-            fi
-        fi
-    fi
-    
+    checkNetCoreDeps sudoIf "yum -y install openssl-libs krb5-libs libicu zlib"      
     checkKeyringDeps sudoIf "yum -y install gnome-keyring libsecret"
     checkBrowserDeps sudoIf "yum -y install desktop-file-utils xorg-x11-utils"
 
@@ -216,20 +203,7 @@ elif type dnf  > /dev/null 2>&1; then
         exitScript 1
     fi
     
-    checkNetCoreDeps sudoIf "dnf -y install openssl-libs krb5-libs libicu zlib"  
-    # Install openssl-compat10 for Fedora 29. Does not exist in 
-    # CentOS, so validate package exists first.
-    if [ $NETCOREDEPS -ne 0 ]; then
-        if ! sudoIf "dnf -q list compat-openssl10" >/dev/null 2>&1; then
-            echo "(*) compat-openssl10 not required."
-        else
-            if ! sudoIf "dnf -y install compat-openssl10"; then
-                echo "(!) compat-openssl10 install failed"
-                exitScript 1
-            fi
-        fi
-    fi
-    
+    checkNetCoreDeps sudoIf "dnf -y install openssl-libs krb5-libs libicu zlib"      
     checkKeyringDeps sudoIf "dnf -y install gnome-keyring libsecret"
     checkBrowserDeps sudoIf "dnf -y install desktop-file-utils xorg-x11-utils"
 
@@ -263,7 +237,7 @@ elif type apk > /dev/null 2>&1; then
         exitScript 1
     fi
 
-    checkNetCoreDeps sudoIf "apk add --no-cache libssl1.0 icu krb5 zlib"
+    checkNetCoreDeps sudoIf "apk add --no-cache libssl1.1 icu krb5 zlib"
     checkKeyringDeps sudoIf "apk add --no-cache gnome-keyring libsecret"
     checkBrowserDeps sudoIf "apk add --no-cache desktop-file-utils xprop"
 


### PR DESCRIPTION
Updating Fedora openssl dependency https://github.com/MicrosoftDocs/live-share/issues/3998 and updating Alpine ssl dependency https://github.com/MicrosoftDocs/live-share/issues/4176.

compat-openssl10 is retired, so all distros of Fedora must now use openssl-lib: https://src.fedoraproject.org/rpms/compat-openssl10//blob/rawhide/f/dead.package

For WSL Alpine, dotnet now relies on libssl1.1: https://docs.microsoft.com/en-us/dotnet/core/install/linux-alpine