### PR TITLE
refactor: add error message for libssl1.1 on Ubuntu 22.04

### DIFF
--- a/scripts/linux-prereqs.sh
+++ b/scripts/linux-prereqs.sh
@@ -171,7 +171,13 @@ elif type apt-get > /dev/null 2>&1; then
     fi
     
     # Install libssl1.1
-    aptSudoIf "install -yq libssl1.1"
+    # in case for Ubuntu 22.04 this will fail, therefore we check and print an alternative installation method
+    # the user can decide on
+    if ! aptSudoIf "install -yq libssl1.1"; then
+        echo "(!) libssl1.1 couldn't be installed, probably you're running on Ubuntu 22.04 or later"
+        echo "    please consider installing libssl1.1 from https://packages.ubuntu.com/focal/libssl1.1"
+        exitScript 1
+    fi
 
     checkKeyringDeps aptSudoIf "install -yq gnome-keyring libsecret-1-0"
     checkBrowserDeps aptSudoIf "install -yq desktop-file-utils x11-utils"


### PR DESCRIPTION
On Ubuntu 22.04 the libssl1.1 command currently fails without any intervention
This is now checked if libssl1.1 install fails and will print the alternate
installation method of libssl1.1 which basically means

1. Adding `deb http://security.ubuntu.com/ubuntu focal-security main` to `/etc/apt/sources.list`
2. Running `apt update` to include the source

This will resolve #4741 and probably #4710, #4646, #4678

The solution described by @ermshiperete here https://github.com/MicrosoftDocs/live-share/issues/4741#issuecomment-1219238297 should also be into consideration, but I haven't tested it for the whole suite of distributions.