### PR TITLE
Remove docs referencing hidden and gitignore files

### DIFF
--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -104,7 +104,7 @@ You can **always reject** (disable anonymous guests) or **always accept** anonym
 
 As a guest, Live Share's remote model gives you quick read/write access to files and folders the host has shared with you without having to sync the entire contents of a project. You can therefore independently navigate and edit files in the entire shared file tree. **However, this freedom does pose some risks to the host.** In concept, a developer could opt to go in and modify source code without your knowledge or see sensitive source code or "secrets" located somewhere in the shared file tree. Consequently, as a host, you may not always want the guest to have access to the entirety of a project you are sharing. Thankfully, an added advantage of this remote model is that you can opt to "exclude" files you do not want to share with anyone without sacrificing on functionality. Your guests can still participate in things like debugging sessions that would normally require access to these files if they wanted to do so on their own.
 
-You can accomplish this by adding a **.vsls.json** file to the folder or project you are sharing. Any settings you add to this json formatted file changes how Live Share processes files. In addition to providing you direct control, these files can also be committed to source control so anyone cloning a project will be able to take advantage of these rules with no additional effort on their part.
+You can accomplish this by adding a **.vsls.json** file to the root of the project you are sharing. This will affect all subfolders in the project. Any settings you add to this json formatted file changes how Live Share processes files. In addition to providing you direct control, these files can also be committed to source control so anyone cloning a project will be able to take advantage of these rules with no additional effort on their part. 
 
 Here's an example .vsls.json file:
 
@@ -123,7 +123,7 @@ Here's an example .vsls.json file:
 > [!NOTE]
 > You can also make the all files/folders you share **read-only** when you start a collaboration session. See [below](#read-only-mode) for details.
 
-The **excludeFiles** property allows you to specify a list of glob file patterns (very much like those found .gitignore files) that prevents Live Share from opening certain files or folders for guests. Be aware that this is inclusive of scenarios like a guest _following or jumping to your edit location, stepping into a file during collaborative debugging, any code navigation features like go to definition, and more._ It is intended for files you never want to share under any circumstances like those containing secrets, certificates, or passwords. For example, since they control security, .vsls.json files are always excluded.
+The **excludeFiles** property allows you to specify a list of glob file patterns (very much like those found .gitignore files) that prevents Live Share from opening certain files or folders for guests. Be aware that this is inclusive of scenarios like a guest _following or jumping to your edit location, stepping into a file during collaborative debugging, any code navigation features like go to definition, and more._ It is intended for files you never want to share under any circumstances like those containing secrets, certificates, or passwords. For example, since they control security, .vsls.json files are always excluded. 
 
 ### Disabling external file sharing
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -111,69 +111,19 @@ Here's an example .vsls.json file:
 ```json
 {
     "$schema": "http://json.schemastore.org/vsls",
-    "gitignore":"none",
     "excludeFiles":[
         "*.p12",
         "*.cer",
         "token",
         ".gitignore"
-    ],
-    "hideFiles": [
-        "bin",
-        "obj"
-    ]
+    ] 
 }
 ```
 
 > [!NOTE]
 > You can also make the all files/folders you share **read-only** when you start a collaboration session. See [below](#read-only-mode) for details.
 
-Let's walk through how these properties change what guests can do.
-
-### Properties
-
 The **excludeFiles** property allows you to specify a list of glob file patterns (very much like those found .gitignore files) that prevents Live Share from opening certain files or folders for guests. Be aware that this is inclusive of scenarios like a guest _following or jumping to your edit location, stepping into a file during collaborative debugging, any code navigation features like go to definition, and more._ It is intended for files you never want to share under any circumstances like those containing secrets, certificates, or passwords. For example, since they control security, .vsls.json files are always excluded.
-
-The **hideFiles** property is similar, but not quite as strict. These files are simply hidden from the file tree. For example, if you happened to step into one of these files during debugging, it is still opened in the editor. This property is primarily useful if you do not have a .gitignore file setup (as would be the case if you are using a different source control system) or if you simply want to augment what is already there to avoid clutter or confusion.
-
-The **gitignore** setting establishes how Live Share should process the contents of .gitignore files in shared folders. By default, any globs found in .gitignore files are treated as if they were specified in the "hideFiles" property. However, you can choose a different behavior using one of the following values:
-
-| Option    | Result                                                                                                                 |
-| --------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `none`    | .gitignore contents are visible to guests in the file tree (assuming they are not filtered by a guest editor setting). |
-| `hide`    | **The default.** Globs inside .gitignore are processed as if they were in the "hideFiles" property.                   |
-| `exclude` | Globs inside .gitignore are processed as if they were in the "excludeFiles" property.                                 |
-
-A downside of the `exclude` setting is that the contents of folders like node_modules are frequently in .gitignore but can be useful to step into during debugging. Consequently, Live Share supports the ability to reverse a rule using "!" in the excludeFiles property. For example, this .vsls.json file would exclude everything in ".gitignore" except for node_modules:
-
-```json
-{
-    "$schema": "http://json.schemastore.org/vsls",
-    "gitignore":"exclude",
-    "excludeFiles":[
-        "!node_modules"
-    ]
-}
-```
-
-The hide and exclude rules are processed separately, so if you still wanted to hide node_modules to reduce clutter without actually excluding it, you can simply edit the file as follows:
-
-```json
-{
-    "$schema": "http://json.schemastore.org/vsls",
-    "gitignore":"exclude",
-    "excludeFiles":[
-        "!node_modules"
-    ],
-    "hideFiles":[
-        "node_modules"
-    ]
-}
-```
-
-### .vsls.json files in sub-folders
-
-Finally, just like .gitignore, .vsls.json files can be placed in sub-folders. Hide/exclude rules are determined by starting with the .vsls.json file in the root folder you have shared (if present) and then walking through at each sub-folder from there leading to a given file to look for .vsls.json files to process. The contents of .vsls.json files in folders farther down the file tree then supplement (or override) rules established at higher levels.
 
 ### Disabling external file sharing
 


### PR DESCRIPTION
We no longer support the hidden files and gitignore file features as part of the .vsls.json.